### PR TITLE
Potential fix for code scanning alert no. 12: Incomplete string escaping or encoding

### DIFF
--- a/webview-ui/src/utils/path-mentions.ts
+++ b/webview-ui/src/utils/path-mentions.ts
@@ -9,7 +9,7 @@
  * @returns A path with spaces escaped
  */
 export function escapeSpaces(path: string): string {
-	return path.replace(/ /g, "\\ ")
+	return path.replace(/\\/g, "\\\\").replace(/ /g, "\\ ")
 }
 
 /**


### PR DESCRIPTION
Potential fix for [https://github.com/SFARPak/ACode/security/code-scanning/12](https://github.com/SFARPak/ACode/security/code-scanning/12)

To fix this problem, we need to ensure that all backslashes in the `path` are themselves escaped before escaping spaces. This is done by first replacing each single backslash (`\`) with a double backslash (`\\`). Then, replace each space (` `) with a backslash followed by a space (`\ `). These two replacements must be performed sequentially in that order—first escape all backslashes, then escape spaces—so there's no ambiguity and the output is parseable.

Specifically, in the file `webview-ui/src/utils/path-mentions.ts` at line 12, update the `escapeSpaces` function to first perform `.replace(/\\/g, "\\\\")` and then `.replace(/ /g, "\\ ")`. No new imports are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
