### PR TITLE
Potential fix for code scanning alert no. 17: Incomplete URL substring sanitization

### DIFF
--- a/src/api/providers/openai.ts
+++ b/src/api/providers/openai.ts
@@ -92,7 +92,14 @@ export class OpenAiHandler extends BaseProvider implements SingleCompletionHandl
 		const enabledLegacyFormat = this.options.openAiLegacyFormat ?? false
 		const isAzureAiInference = this._isAzureAiInference(modelUrl)
 		const deepseekReasoner = modelId.includes("deepseek-reasoner") || enabledR1Format
-		const ark = modelUrl.includes(".volces.com")
+		let ark = false;
+		try {
+			const parsedUrl = new URL(modelUrl);
+			const hostname = parsedUrl.hostname;
+			ark = (hostname === "volces.com" || hostname.endsWith(".volces.com"));
+		} catch (e) {
+			ark = false;
+		}
 
 		if (modelId.includes("o1") || modelId.includes("o3") || modelId.includes("o4")) {
 			yield* this.handleO3FamilyMessage(modelId, systemPrompt, messages)


### PR DESCRIPTION
Potential fix for [https://github.com/SFARPak/ACode/security/code-scanning/17](https://github.com/SFARPak/ACode/security/code-scanning/17)

The best way to fix the problem is to ensure that any checks regarding the domain should be made against the parsed URL's hostname, not against the entire URL as a string. Specifically, instead of `modelUrl.includes(".volces.com")`, the code should parse the URL and verify whether the hostname equals `volces.com` or ends with `.volces.com` (to allow subdomains). To achieve this, you should use the standard Node.js `url` module (or the WHATWG `URL` class) to extract the hostname, and then perform proper checks. The fix should be implemented in `src/api/providers/openai.ts`, updating line 95. If parsing logic is not already present, import the required standard library.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
