### PR TITLE
Potential fix for code scanning alert no. 16: Shell command built from environment values

### DIFF
--- a/packages/build/src/esbuild.ts
+++ b/packages/build/src/esbuild.ts
@@ -1,6 +1,6 @@
 import * as fs from "fs"
 import * as path from "path"
-import { execSync } from "child_process"
+import { execSync, execFileSync } from "child_process"
 
 import { ViewsContainer, Views, Menus, Configuration, contributesSchema } from "./types.js"
 
@@ -47,7 +47,7 @@ function rmDir(dirPath: string, maxRetries: number = 5): void {
 					// Try to clear readonly flags on Windows.
 					if (process.platform === "win32") {
 						try {
-							execSync(`attrib -R "${dirPath}\\*.*" /S /D`, { stdio: "ignore" })
+							execFileSync("attrib", ["-R", `${dirPath}\\*.*`, "/S", "/D"], { stdio: "ignore" })
 						} catch {
 							// Ignore attrib errors.
 						}


### PR DESCRIPTION
Potential fix for [https://github.com/SFARPak/ACode/security/code-scanning/16](https://github.com/SFARPak/ACode/security/code-scanning/16)

To fix the issue, avoid constructing the `attrib` shell command by string interpolation and passing it to `execSync`, which will spawn a subshell and allow possible injection via the interpolated path.  
Instead, invoke the `attrib.exe` command directly with its arguments using `execFileSync`, passing the arguments as an array so that no shell interpretation occurs. This avoids special character problems and command injection risks. Specifically, in `rmDir`, replace:

```ts
execSync(`attrib -R "${dirPath}\\*.*" /S /D`, { stdio: "ignore" })
```
with: 
```ts
execFileSync("attrib", ["-R", `${dirPath}\\*.*`, "/S", "/D"], { stdio: "ignore" })
```

Additionally, import `execFileSync` from `child_process` at the top of the file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
